### PR TITLE
Adds static methods to IdioticClient

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,23 @@
         "destructuring": "any",
         "ignoreReadBeforeAssign": false
       }
+    ],
+    "valid-jsdoc": [
+      "warn",
+      {
+        "requireReturn": false,
+        "requireReturnDescription": false,
+        "preferType": {
+          "String": "string",
+          "Number": "number",
+          "Boolean": "boolean",
+          "Symbol": "symbol",
+          "function": "Function",
+          "object": "Object",
+          "Date": "date",
+          "error": "Error"
+        }
+      }
     ]
   }
 }

--- a/src/lib/Client.js
+++ b/src/lib/Client.js
@@ -16,7 +16,7 @@ class IdioticClient {
    */
 
   /**
-   * @param {String} token Idiotic API token
+   * @param {string} token Idiotic API token
    * @param {IdioticClientOptions} [options] Client options
    */
   constructor(token, options = {}) {
@@ -28,16 +28,12 @@ class IdioticClient {
      * @type {String}
      */
     this.token = token;
-    /**
-     * Client options
-     * @type {Object}
-     */
-    this.options = options;
+
     /**
      * Whether to use the dev endpoint
      * @type {Boolean}
      */
-    this.dev = options.dev || false;
+    this.dev = "dev" in options ? options.dev : false;
     /**
      * Base URL for Idiot's Guide API
      * @type {String}
@@ -49,7 +45,7 @@ class IdioticClient {
 
   /**
    * Blame endpoint
-   * @param {String} name text to except back
+   * @param {string} name text to except back
    * @returns {Promise<Buffer>}
    */
   blame(name) {
@@ -58,7 +54,7 @@ class IdioticClient {
 
   /**
    * Pls endpoint
-   * @param {String} name text to except back
+   * @param {string} name text to except back
    * @returns {Promise<Buffer>}
    */
   pls(name) {
@@ -67,7 +63,7 @@ class IdioticClient {
 
   /**
    * Snapchat endpoint
-   * @param {String} text text to except back
+   * @param {string} text text to except back
    * @returns {Promise<Buffer>}
    */
   snapchat(text) {
@@ -78,8 +74,8 @@ class IdioticClient {
 
   /**
    * Achievement endpoint
-   * @param {String} avatar Image you except to be used
-   * @param {String} text text to except back
+   * @param {string} avatar Image you except to be used
+   * @param {string} text text to except back
    * @returns {Promise<Buffer>}
    */
   achievement(avatar, text) {
@@ -89,8 +85,8 @@ class IdioticClient {
 
   /**
    * TheSearch endpoint
-   * @param {String} avatar Image you except to be used
-   * @param {String} text text to except back
+   * @param {string} avatar Image you except to be used
+   * @param {string} text text to except back
    * @returns {Promise<Buffer>}
    */
   theSearch(avatar, text) {
@@ -100,8 +96,8 @@ class IdioticClient {
 
   /**
    * Missing endpoint
-   * @param {String} avatar Image you except to be used
-   * @param {String} text text to except back
+   * @param {string} avatar Image you except to be used
+   * @param {string} text text to except back
    * @returns {Promise<Buffer>}
    */
   missing(avatar, text) {
@@ -112,8 +108,8 @@ class IdioticClient {
 
   /**
    * Steam endpoint
-   * @param {String} avatar Image you except to be used
-   * @param {String} text text to except back
+   * @param {string} avatar Image you except to be used
+   * @param {string} text text to except back
    * @returns {Promise<Buffer>}
    */
   steam(avatar, text) {
@@ -124,8 +120,8 @@ class IdioticClient {
 
   /**
    * Missing endpoint
-   * @param {String} avatar Image you except to be used
-   * @param {String} text text to except back
+   * @param {string} avatar Image you except to be used
+   * @param {string} suggestion text to except back
    * @returns {Promise<Buffer>}
    */
   suggestion(avatar, suggestion) {
@@ -138,7 +134,7 @@ class IdioticClient {
 
   /**
    * Beautiful endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   beautiful(avatar) {
@@ -148,7 +144,7 @@ class IdioticClient {
 
   /**
    * Facepalm endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   facepalm(avatar) {
@@ -158,7 +154,7 @@ class IdioticClient {
 
   /**
    * Respect endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   respect(avatar) {
@@ -168,7 +164,7 @@ class IdioticClient {
 
   /**
    * Stepped endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   stepped(avatar) {
@@ -178,7 +174,7 @@ class IdioticClient {
 
   /**
    * Tattoo endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   tattoo(avatar) {
@@ -188,7 +184,7 @@ class IdioticClient {
 
   /**
    * Triggered endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   triggered(avatar) {
@@ -198,7 +194,7 @@ class IdioticClient {
 
   /**
    * VaultBoy endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   vaultBoy(avatar) {
@@ -208,7 +204,7 @@ class IdioticClient {
 
   /**
    * Wanted endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   wanted(avatar) {
@@ -218,7 +214,7 @@ class IdioticClient {
 
   /**
    * Karen endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   karen(avatar) {
@@ -229,7 +225,7 @@ class IdioticClient {
 
   /**
    * Challenger endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   challenger(avatar) {
@@ -240,7 +236,7 @@ class IdioticClient {
 
   /**
    * Bobross endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   bobRoss(avatar) {
@@ -251,7 +247,7 @@ class IdioticClient {
 
   /**
    * WaifuInsult endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   waifuInsult(avatar) {
@@ -262,7 +258,7 @@ class IdioticClient {
 
   /**
    * HeavyFear endpoint
-   * @param {String} avatar Image you expect to be used
+   * @param {string} avatar Image you expect to be used
    * @returns {Promise<Buffer>} 
    */
   heavyFear(avatar) {
@@ -273,7 +269,7 @@ class IdioticClient {
 
   /**
    * WreckIt endpoint
-   * @param {String} avatar Image you expect to be used
+   * @param {string} avatar Image you expect to be used
    * @returns {Promise<Buffer>} 
    */
   wreckIt(avatar) {
@@ -284,7 +280,7 @@ class IdioticClient {
 
   /**
    * Painting endpoint
-   * @param {String} avatar Image you expect to be used
+   * @param {string} avatar Image you expect to be used
    * @returns {Promise<Buffer>} 
    */
   painting(avatar) {
@@ -295,7 +291,7 @@ class IdioticClient {
 
   /**
    * Garbage endpoint
-   * @param {String} avatar Image you except to be used
+   * @param {string} avatar Image you except to be used
    * @returns {Promise<Buffer>}
    */
   garbage(avatar) {
@@ -308,8 +304,8 @@ class IdioticClient {
 
   /**
    * BatSlap endpoint
-   * @param {String} slapper Image you expect to be used
-   * @param {String} slapped Image you expect to be used
+   * @param {string} slapper Image you expect to be used
+   * @param {string} slapped Image you expect to be used
    * @returns {Promise<Buffer>}
    */
   batSlap(slapper, slapped) {
@@ -320,8 +316,8 @@ class IdioticClient {
 
   /**
    * FanSlap endpoint
-   * @param {String} slapper Image you expect to be used
-   * @param {String} slapped Image you expect to be used
+   * @param {string} slapper Image you expect to be used
+   * @param {string} slapped Image you expect to be used
    * @returns {Promise<Buffer>}
    */
   fanSlap(slapper, slapped) {
@@ -332,8 +328,8 @@ class IdioticClient {
 
   /**
    * SuperPunch endpoint
-   * @param {String} puncher Image you expect to be used
-   * @param {String} punched Image you expect to be used
+   * @param {string} puncher Image you expect to be used
+   * @param {string} punched Image you expect to be used
    * @returns {Promise<Buffer>}
    */ 
   superPunch(puncher, punched) {
@@ -344,8 +340,8 @@ class IdioticClient {
 
   /**
    * Crush endpoint
-   * @param {String} crusher Image you expect to be used
-   * @param {String} crush Image you expect to be used
+   * @param {string} crusher Image you expect to be used
+   * @param {string} crush Image you expect to be used
    * @returns {Promise<Buffer>}
    */
   crush(crusher, crush) {
@@ -356,8 +352,8 @@ class IdioticClient {
 
   /**
    * Confused endpoint
-   * @param {String} avatar Image you expect to be used
-   * @param {String} slapped Image you expect to be used
+   * @param {string} avatar Image you expect to be used
+   * @param {string} photo Image you expect to be used
    * @returns {Promise<Buffer>}
    */
   confused(avatar, photo) {
@@ -369,8 +365,8 @@ class IdioticClient {
 
   /**
    * SuperSpank endpoint
-   * @param {String} spanker Image you expect to be used
-   * @param {String} spanked Image you expect to be used
+   * @param {string} spanker Image you expect to be used
+   * @param {string} spanked Image you expect to be used
    * @returns {Promise<Buffer>}
    */ 
   superSpank(spanker, spanked) {
@@ -382,8 +378,8 @@ class IdioticClient {
 
   /**
    * Tinder endpoint
-   * @param {String} avatar Image you expect to be used
-   * @param {String} match Image you expect to be used
+   * @param {string} avatar Image you expect to be used
+   * @param {string} match Image you expect to be used
    * @returns {Promise<Buffer>}
    */ 
   tinderMatch(avatar, match) {
@@ -395,7 +391,7 @@ class IdioticClient {
 
   /**
    * Color endpoint
-   * @param {String} color Supply a color code in any of these supported formats `hex`, `rgb`, `rgba`
+   * @param {string} color Supply a color code in any of these supported formats `hex`, `rgb`, `rgba`
    * @returns {Promise<Buffer>}
    */ 
   color(...args) {
@@ -404,7 +400,7 @@ class IdioticClient {
   
   /**
    * Colour endpoint
-   * @param {String} colour Supply a colour code in any of these supported formats `hex`, `rgb`, `rgba`
+   * @param {string} colour Supply a colour code in any of these supported formats `hex`, `rgb`, `rgba`
    * @returns {Promise<Buffer>}
    */ 
   colour(colour) {
@@ -416,11 +412,11 @@ class IdioticClient {
 
   /**
    *
-   * @param {String} [version="gearz"] The type/version of greeting image you want to use
-   * @param {Boolean} [bot=false] A boolean saying if the user is a bot or not
-   * @param {String} avatar Avatar url
-   * @param {String} usertag User's tag, format: username#discrim
-   * @param {String} guild guild name and guild member count seperated by #, format: guildname#memberCount
+   * @param {string} [version="gearz"] The type/version of greeting image you want to use
+   * @param {boolean} [bot=false] A boolean saying if the user is a bot or not
+   * @param {string} avatar Avatar url
+   * @param {string} usertag User's tag, format: username#discrim
+   * @param {string} guild guild name and guild member count seperated by #, format: guildname#memberCount
    * @returns {Promise<Buffer>}
    */
   welcome(version = "gearz", bot = false, avatar, usertag, guild) {
@@ -432,10 +428,10 @@ class IdioticClient {
 
   /**
    *
-   * @param {String} [version="gearz"] The type/version of farewell image you want to use
-   * @param {Boolean} [bot=false] A boolean saying if the user is a bot or not
-   * @param {String} avatar Avatar url
-   * @param {String} usertag User's tag, format: username#discrim
+   * @param {string} [version="gearz"] The type/version of farewell image you want to use
+   * @param {boolean} [bot=false] A boolean saying if the user is a bot or not
+   * @param {string} avatar Avatar url
+   * @param {string} usertag User's tag, format: username#discrim
    * @returns {Promise<Buffer>}
    */
   goodbye(version = "gearz", bot = false, avatar, usertag) {
@@ -555,7 +551,7 @@ class IdioticClient {
 
   /**
    * A private method used to get endpoints with querys
-   * @param {String} endpoint endpoint string
+   * @param {string} endpoint endpoint string
    * @param {Object} [query={}] query object
    * @returns {Promise<any>}
    * @private
@@ -573,5 +569,14 @@ class IdioticClient {
   }
 
 }
+
+const notAllowedMethods = ["constructor", "_get"];
+const METHODS = Object.getOwnPropertyNames(IdioticClient.prototype).filter(method => !notAllowedMethods.includes(method));
+for (const method of METHODS) Object.defineProperty(IdioticClient, method, {
+  value: function(token, ...params) {
+    if (typeof token === "object" && token !== null) return new IdioticClient(token.token, token)[method](...params);
+    else return new IdioticClient(token)[method](...params);
+  }
+});
 
 module.exports = IdioticClient;


### PR DESCRIPTION
Adds static methods to IdioticClient
for example

```javascript
const { Client } = require("idiotic-api");
Client.blame("token", "Jacz");
// or if you want to use dev
Client.blame({ token: "token here", dev: true }, "Jacz");
// Instead of
new Client(token).blame("Jacz");
// or with dev
new Client(token, { dev: true }).blame("Jacz");
```
Keep in mind, `new Client` is still the prefered way